### PR TITLE
chore(pages): fix pages build, use appropriate node version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: taiga-family/ci/actions/setup/checkout@v1.31.2
       - uses: taiga-family/ci/actions/setup/variables@v1.31.2
       - uses: taiga-family/ci/actions/setup/node@v1.31.2
+        with: 
+          node-version: 16.x
       - run: npx nx run demo:build-gh-pages
       - uses: taiga-family/ci/actions/deploy/github-pages@v1.31.2
         with:


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behavior?

gh-pages build now working (incorrect node version)

## What is the new behavior?

gh-pages build should work
