### PR TITLE
fix: bump to up version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ It is a small tool that allows you to add and render multiple apps on one page. 
 
 ## Angular version support
 
-| Version | Angular version |
-| ------- | --------------- |
-| v2.x    | 16+             |
-| v1.x    | 12 - 15         |
+| Microzord Version | Angular version |
+| ----------------- | --------------- |
+| v2.x              | 16+             |
+| v1.x              | 12 - 15         |
 
 ## Installation and usage
 

--- a/libs/angular/package.json
+++ b/libs/angular/package.json
@@ -27,7 +27,8 @@
   "authors": ["Igor Katsuba <katsuba.igor@gmail.ru>", "Roman Sedov <79601794011@ya.ru>"],
   "contributors": [
     "Igor Katsuba <katsuba.igor@gmail.ru>",
-    "Roman Sedov <79601794011@ya.ru>"
+    "Roman Sedov <79601794011@ya.ru>",
+    "Vsevolod Arutyunov <sevaru@inbox.ru>"
   ],
   "repository": "https://github.com/taiga-family/microzord",
   "homepage": "https://taiga-family.github.io/microzord"

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -24,7 +24,8 @@
   "authors": ["Igor Katsuba <katsuba.igor@gmail.ru>", "Roman Sedov <79601794011@ya.ru>"],
   "contributors": [
     "Igor Katsuba <katsuba.igor@gmail.ru>",
-    "Roman Sedov <79601794011@ya.ru>"
+    "Roman Sedov <79601794011@ya.ru>",
+    "Vsevolod Arutyunov <sevaru@inbox.ru>"
   ],
   "repository": "https://github.com/taiga-family/microzord",
   "homepage": "https://taiga-family.github.io/microzord"


### PR DESCRIPTION
BREAKING CHANGE: drop support for angular < 16

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?

Version is not bumped

## What is the new behaviour?
